### PR TITLE
TT2-1568: Switching on DeletionProtectionEnabled flag for dynamoDB table

### DIFF
--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -3,6 +3,7 @@ name: Package event processing infrastructure
 on:
   push:
     branches:
+      - TT2-1568
       - main
     paths:
       - infrastructure/event-processing/**

--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -3,7 +3,6 @@ name: Package event processing infrastructure
 on:
   push:
     branches:
-      - TT2-1568
       - main
     paths:
       - infrastructure/event-processing/**

--- a/infrastructure/audit/template.yaml
+++ b/infrastructure/audit/template.yaml
@@ -236,6 +236,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   ############################
   # End: Batch Job Resources #

--- a/infrastructure/data-analysis/template.yaml
+++ b/infrastructure/data-analysis/template.yaml
@@ -256,6 +256,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   ###############
   # WAF Resources

--- a/infrastructure/event-processing/template.yaml
+++ b/infrastructure/event-processing/template.yaml
@@ -43,6 +43,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   ################
   # SSM Parameters

--- a/infrastructure/query-results/template.yaml
+++ b/infrastructure/query-results/template.yaml
@@ -97,6 +97,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   SecureFraudApiWafIpSet:
     Condition: NotTestEnvironment

--- a/infrastructure/rp-events/template.yaml
+++ b/infrastructure/rp-events/template.yaml
@@ -52,6 +52,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   RelyingPartyPairwiseMappingTable:
     Type: AWS::DynamoDB::Table
@@ -96,6 +97,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   RelyingPartyPairwiseMappingTableCrossAccountAccessRole:
     Type: AWS::IAM::Role

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -71,6 +71,7 @@ Resources:
       Tags:
         - Key: BackupFrequency
           Value: Daily
+      DeletionProtectionEnabled: true
 
   ###############
   # WAF Resources


### PR DESCRIPTION
Ticket Number: #TT2-1568 🎫

💡 Description
Enabling DeletionProtectionEnabled on dynamoDB tables within infra repo to prevent accidental deletion on the aws console

🖼️  Screenshots:
<img width="1728" alt="Screenshot 2024-03-25 at 10 59 05" src="https://github.com/govuk-one-login/txma-infra/assets/146729221/c7eb9f20-d845-455a-a3db-39857a7e82f3">

