### PR TITLE
TT2-1595: Disabing ttl to modify reserved attribute name

### DIFF
--- a/infrastructure/event-processing/template.yaml
+++ b/infrastructure/event-processing/template.yaml
@@ -32,7 +32,7 @@ Resources:
           KeyType: HASH
       TimeToLiveSpecification:
         AttributeName: ttl
-        Enabled: true
+        Enabled: false
       BillingMode: PAY_PER_REQUEST
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
Ticket Number: #[TT2-1595](https://govukverify.atlassian.net/browse/TT2-1595) 🎫

💡 Description
We cannot use fields `ttl` as attribute name as dynamoDB returns error when querying against it as it is a reserved word.
It is not possible to modify attribute name for enabled field hence disabling it in this PR and would raise next one with the modified field


[TT2-1595]: https://govukverify.atlassian.net/browse/TT2-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ