### PR TITLE
updating devplatform-upload-action to v3.8.1

### DIFF
--- a/.github/workflows/package-audit-test-tools.yaml
+++ b/.github/workflows/package-audit-test-tools.yaml
@@ -83,7 +83,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-audit-test-tools.yaml
+++ b/.github/workflows/package-audit-test-tools.yaml
@@ -83,7 +83,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-audit.yaml
+++ b/.github/workflows/package-audit.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-audit.yaml
+++ b/.github/workflows/package-audit.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -77,7 +77,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -77,7 +77,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -115,7 +115,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -115,7 +115,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-rp-events.yaml
+++ b/.github/workflows/package-rp-events.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-rp-events.yaml
+++ b/.github/workflows/package-rp-events.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-shared-signals.yaml
+++ b/.github/workflows/package-shared-signals.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-shared-signals.yaml
+++ b/.github/workflows/package-shared-signals.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.3
+        uses: govuk-one-login/di-devplatform-upload-action@v3.8.1
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}


### PR DESCRIPTION
updating devplatform-upload-action to v3.8.1

The "alphagov" repo is archived and we moved to "govuk-one-login" in october last year.





this is an update to the GitHub action that includes updated to Dyntrace stats from the pipeline.
https://github.com/govuk-one-login/devplatform-upload-action/releases/tag/v3.8.1





Ticket Number: #[Your Ticket Number] 🎫
Documentation Link(s): [:books: Does this relate to an ADR/RFC/Spike ticket?]
💡 Description
[Provide a brief but clear description of the changes made in this pull request. Explain why these changes are necessary and how they address the issue or feature request.]

✨ Changes Made
[List the specific changes made in bullet points. Be as detailed as necessary.]
🧪 Testing Instructions/Notes
[Provide step-by-step instructions for testing the changes made in this pull request. Were there any tests you weren't able to include but would have liked to? ]

:frame_with_picture: Screenshots (if applicable)
[Include any screenshots or visual representations of the changes. Delete this section if not applicable.]

🤝 Related Pull Requests
[List any related pull requests that need to be reviewed or merged alongside this one.]
:white_tick: Documentation update
[Please provide proper documentation or update existing documentation both in the README and within our confluence pages. If there is any documentation you have yet to update please detail it here. ]
📝 Additional Notes
[Add any additional information, context, or notes that reviewers or contributors should be aware of.]
