### PR TITLE
TT2-1717: Modifying DB back up frequency to Bihourly

### DIFF
--- a/infrastructure/audit/template.yaml
+++ b/infrastructure/audit/template.yaml
@@ -235,7 +235,7 @@ Resources:
       TableName: !Sub ${AWS::StackName}-event-replay-file-mapping-table
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   ############################

--- a/infrastructure/data-analysis/template.yaml
+++ b/infrastructure/data-analysis/template.yaml
@@ -255,7 +255,7 @@ Resources:
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   ###############

--- a/infrastructure/event-processing/template.yaml
+++ b/infrastructure/event-processing/template.yaml
@@ -42,7 +42,7 @@ Resources:
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   ################

--- a/infrastructure/query-results/template.yaml
+++ b/infrastructure/query-results/template.yaml
@@ -96,7 +96,7 @@ Resources:
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   SecureFraudApiWafIpSet:

--- a/infrastructure/rp-events/template.yaml
+++ b/infrastructure/rp-events/template.yaml
@@ -51,7 +51,7 @@ Resources:
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   RelyingPartyPairwiseMappingTable:
@@ -96,7 +96,7 @@ Resources:
         KMSMasterKeyId: '{{resolve:ssm:DatabaseKmsKeyArn}}'
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   RelyingPartyPairwiseMappingTableCrossAccountAccessRole:

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -70,7 +70,7 @@ Resources:
       TableName: !Sub ${AWS::StackName}-user-config
       Tags:
         - Key: BackupFrequency
-          Value: Daily
+          Value: Bihourly
       DeletionProtectionEnabled: true
 
   ###############


### PR DESCRIPTION
Ticket Number: #[TT2-1717](https://govukverify.atlassian.net/browse/TT2-1717) 🎫

💡 Description
Modifying dynamo DB scheduled backup frequency to be every 2 hours in line with the TxMA RPO https://github.com/govuk-one-login/architecture/blob/main/adr/0048-rto-rpo.md 

🧪 Testing Instructions/Notes

Tested by deploying in Dev
<img width="815" alt="Screenshot 2024-05-14 at 09 47 56" src="https://github.com/govuk-one-login/txma-infra/assets/26764987/00d493a0-7f6f-446f-bb6a-c6cca151918d">





[TT2-1717]: https://govukverify.atlassian.net/browse/TT2-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ