### PR TITLE
TT2-1976 Add alarms

### DIFF
--- a/infrastructure/audit/template.yaml
+++ b/infrastructure/audit/template.yaml
@@ -409,3 +409,64 @@ Resources:
   #######################
   # End: SSM Parameters #
   #######################
+
+  ############################################
+  # Start: Monitoring and alerting resources #
+  ############################################
+
+  AgeOfOldestMessageOnAuditFileGlacierRestoreQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors the age of the oldest message on the Audit File Glacier Restore Queue.
+        If messages remain on the queue for more than one hour this alarm is triggered.
+      AlarmName: !Sub ${AWS::StackName}-audit-file-glacier-restore-queue-oldest-message-age
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt AuditFileGlacierRestoreQueue.QueueName
+      EvaluationPeriods: 1
+      MetricName: ApproximateAgeOfOldestMessage
+      Namespace: AWS/SQS
+      Statistic: Maximum
+      Period: 60
+      Threshold: 3600
+      TreatMissingData: ignore
+
+  AuditFileGlacierRestoreDLQHasMessages:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors the number of messages on the Dead Letter Queue for the Audit File Glacier Restore Queue.
+        If there any messages in this queue this alarm is triggered.
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      EvaluationPeriods: 1
+      TreatMissingData: notBreaching
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt AuditFileGlacierRestoreDeadLetterQueue.QueueName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Period: 60
+      Statistic: Maximum
+
+  ##########################################
+  # End: Monitoring and alerting resources #
+  ##########################################
+
+Outputs:
+  AuditFileGlacierRestoreQueueAlarm:
+    Value: !Ref AgeOfOldestMessageOnAuditFileGlacierRestoreQueueAlarm
+    Export:
+      Name: AgeOfOldestMessageOnAuditFileGlacierRestoreQueueAlarm
+  AuditFileGlacierRestoreDeadLetterQueueAlarm:
+    Value: !Ref AuditFileGlacierRestoreDLQHasMessages
+    Export:
+      Name: AuditFileGlacierRestoreDLQHasMessages


### PR DESCRIPTION
Ticket Number: [TT2-1976](https://govukverify.atlassian.net/browse/TT2-1976) 🎫
Documentation Link(s): [Confluence](https://govukverify.atlassian.net/wiki/spaces/TMA/pages/4295360647/Lambdas+across+TxMA#Repo%3A-txma-event-self-serve) :books:

💡 Description

- Add alarms for audit file glacier restore queue and dlq
- Export alarms so they can be used in txma-event-replay

✨ Changes Made

- Add IaC code for alarms and associated outputs

:frame_with_picture: Screenshots (if applicable)

🤝 Related Pull Requests

- https://github.com/govuk-one-login/txma-event-replay/pull/88

:white_tick: Documentation update

- Confluence link will need to be updated when this is merged

[TT2-1976]: https://govukverify.atlassian.net/browse/TT2-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ