### PR TITLE
DPT-738 - switch to ES256 algo for set signing

### DIFF
--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -376,6 +376,7 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       Description: KMS key for SET signing and verification. Deployed on 2024/11/11
+      KeySpec: 'ECC_NIST_P256'
       KeyPolicy:
         Version: '2012-10-17'
         Statement:

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -375,7 +375,7 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      Description: KMS key for SET signing and verification. Deployed on 2024/11/11
+      Description: KMS key for SET signing and verification. Deployed on 2024/11/12
       KeySpec: 'ECC_NIST_P256'
       KeyPolicy:
         Version: '2012-10-17'


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/DPT-738

part of switching from RS256 to ES256.

the 2nd set signing key uses the appropriate key spec