### PR TITLE
DPT-725 - use pipeline names

### DIFF
--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -35,19 +35,19 @@ Conditions:
       !Equals [!Ref Environment, staging]
     ]
 
-# sam lint doesnt like unused mappings so commenting out to use in part 2 to allow pipelines to run
-# Mappings:
-#   EnvironmentPipelineNames:
-#     dev:
-#       PipelineName: 'dev'
-#     build:
-#       PipelineName: 'build'
-#     staging:
-#       PipelineName: 'stg'
-#     integration:
-#       PipelineName: 'int'
-#     production:
-#       PipelineName: 'prod'
+# EnvironmentPipelineNames are the shortened environment names that the pipeline uses
+Mappings:
+  EnvironmentPipelineNames:
+    dev:
+      PipelineName: 'dev'
+    build:
+      PipelineName: 'build'
+    staging:
+      PipelineName: 'stg'
+    integration:
+      PipelineName: 'int'
+    production:
+      PipelineName: 'prod'
 
 Resources:
   ####################
@@ -412,8 +412,14 @@ Resources:
               Effect: Allow
               Principal:
                 AWS:
-                  Fn::ImportValue:
-                    'Fn::Sub': ssf-${Environment}-pipeline-TestRoleArn
+                  Fn::ImportValue: !Sub
+                    - ssf-${pipelineFriendEnv}-pipeline-TestRoleArn
+                    - pipelineFriendEnv:
+                        !FindInMap [
+                          EnvironmentPipelineNames,
+                          !Ref Environment,
+                          PipelineName
+                        ]
               Action:
                 - kms:*
               Resource: '*'
@@ -448,7 +454,14 @@ Resources:
               Effect: Allow
               Principal:
                 AWS:
-                  Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRoleArn
+                  Fn::ImportValue: !Sub
+                    - ssf-${pipelineFriendEnv}-pipeline-TestRoleArn
+                    - pipelineFriendEnv:
+                        !FindInMap [
+                          EnvironmentPipelineNames,
+                          !Ref Environment,
+                          PipelineName
+                        ]
               Action:
                 - kms:*
               Resource: '*'

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -393,7 +393,8 @@ Resources:
           - Sid: AllowTestRoleAccess
             Effect: Allow
             Principal:
-              AWS: !ImportValue ssf-build-pipeline-TestRole
+              AWS:
+                Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRole
             Action:
               - kms:*
             Resource: '*'

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -35,6 +35,19 @@ Conditions:
       !Equals [!Ref Environment, staging]
     ]
 
+Mappings:
+  EnvironmentPipelineNames:
+    dev:
+      PipelineName: 'dev'
+    build:
+      PipelineName: 'build'
+    staging:
+      PipelineName: 'stg'
+    integration:
+      PipelineName: 'int'
+    production:
+      PipelineName: 'prod'
+
 Resources:
   ####################
   # DynamoDB Resources
@@ -398,7 +411,8 @@ Resources:
               Effect: Allow
               Principal:
                 AWS:
-                  Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRoleArn
+                  Fn::ImportValue:
+                    'Fn::Sub': ssf-${Environment}-pipeline-TestRoleArn
               Action:
                 - kms:*
               Resource: '*'

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -35,6 +35,7 @@ Conditions:
       !Equals [!Ref Environment, staging]
     ]
 
+# sam lint doesnt like unused mappings so commenting out to use in part 2 to allow pipelines to run
 # Mappings:
 #   EnvironmentPipelineNames:
 #     dev:

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -35,18 +35,18 @@ Conditions:
       !Equals [!Ref Environment, staging]
     ]
 
-Mappings:
-  EnvironmentPipelineNames:
-    dev:
-      PipelineName: 'dev'
-    build:
-      PipelineName: 'build'
-    staging:
-      PipelineName: 'stg'
-    integration:
-      PipelineName: 'int'
-    production:
-      PipelineName: 'prod'
+# Mappings:
+#   EnvironmentPipelineNames:
+#     dev:
+#       PipelineName: 'dev'
+#     build:
+#       PipelineName: 'build'
+#     staging:
+#       PipelineName: 'stg'
+#     integration:
+#       PipelineName: 'int'
+#     production:
+#       PipelineName: 'prod'
 
 Resources:
   ####################

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -390,6 +390,13 @@ Resources:
             Action:
               - kms:*
             Resource: '*'
+          - Sid: AllowTestRoleAccess
+            Effect: Allow
+            Principal:
+              AWS: !ImportValue ssf-build-pipeline-TestRole
+            Action:
+              - kms:*
+            Resource: '*'
 
   SETSigningKMSKeyAlias2:
     Type: 'AWS::KMS::Alias'

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -20,6 +20,8 @@ Parameters:
 Conditions:
   IsDev: !Equals [!Ref Environment, dev]
   IsStaging: !Equals [!Ref Environment, staging]
+  IsBuildOrStaging:
+    !Or [!Equals [!Ref Environment, build], !Equals [!Ref Environment, staging]]
   NotTestEnvironment:
     !Or [
       !Equals [!Ref Environment, production],
@@ -390,14 +392,17 @@ Resources:
             Action:
               - kms:*
             Resource: '*'
-          - Sid: AllowTestRoleAccess
-            Effect: Allow
-            Principal:
-              AWS:
-                Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRole
-            Action:
-              - kms:*
-            Resource: '*'
+          - !If
+            - IsBuildOrStaging
+            - Sid: AllowTestRoleAccess
+              Effect: Allow
+              Principal:
+                AWS:
+                  Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRole
+              Action:
+                - kms:*
+              Resource: '*'
+            - !Ref AWS::NoValue
 
   SETSigningKMSKeyAlias2:
     Type: 'AWS::KMS::Alias'

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -427,6 +427,17 @@ Resources:
             Action:
               - kms:*
             Resource: '*'
+          - !If
+            - IsBuildOrStaging
+            - Sid: AllowTestRoleAccess
+              Effect: Allow
+              Principal:
+                AWS:
+                  Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRoleArn
+              Action:
+                - kms:*
+              Resource: '*'
+            - !Ref AWS::NoValue
       KeySpec: RSA_4096
       KeyUsage: SIGN_VERIFY
 

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -398,7 +398,7 @@ Resources:
               Effect: Allow
               Principal:
                 AWS:
-                  Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRole
+                  Fn::ImportValue: !Sub ssf-${Environment}-pipeline-TestRoleArn
               Action:
                 - kms:*
               Resource: '*'


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/DPT-725

the test role uses the environment names that the pipeline uses. this should allow for the pipeline to correctly import the test role