### PR TITLE
Node18 to 22

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "arcanis.vscode-zipfs",
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,13 @@
 {
   "recommendations": [
+    "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "editorconfig.editorconfig",
-    "dbaeumer.vscode-eslint"
+    "orta.vscode-jest",
+    "mhutchie.git-graph",
+    "visualstudioexptteam.vscodeintellicode",
+    "mylesmurphy.prettify-ts",
+    "yoavbls.pretty-ts-errors",
+    "sonarsource.sonarlint-vscode",
+    "redhat.vscode-yaml"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,9 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "eslint.nodePath": "./node_modules/eslint",
-  "prettier.prettierPath": "./node_modules/prettier",
-  "search.exclude": {
-    "**/node_modules": true,
-    "**/dist": true
-  },
-  "typescript.tsdk": "./node_modules/typescript/lib",
+  "editor.formatOnSave": true,
+  "files.autoSave": "onFocusChange",
+  "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
+  // required for cloudformation so the yaml extensions doesnt generate errors for these tags
   "yaml.customTags": [
     "!Base64 scalar",
     "!Cidr scalar",

--- a/infrastructure/audit-test-tools/package.json
+++ b/infrastructure/audit-test-tools/package.json
@@ -30,5 +30,8 @@
     "ts-node": "10.9.2",
     "typescript": "5.8.2",
     "yaml-cfn": "0.3.2"
+  },
+  "engines": {
+    "node": "^22.0.0"
   }
 }

--- a/infrastructure/audit-test-tools/template.yaml
+++ b/infrastructure/audit-test-tools/template.yaml
@@ -85,7 +85,7 @@ Globals:
     PermissionsBoundary:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     ReservedConcurrentExecutions: 10
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     Timeout: 30
     MemorySize: 256
     Architectures:

--- a/infrastructure/dev-tools/package.json
+++ b/infrastructure/dev-tools/package.json
@@ -36,5 +36,8 @@
     "ts-node": "10.9.2",
     "typescript": "5.8.2",
     "yaml-cfn": "0.3.2"
+  },
+  "engines": {
+    "node": "^22.0.0"
   }
 }

--- a/infrastructure/dev-tools/template.yaml
+++ b/infrastructure/dev-tools/template.yaml
@@ -86,7 +86,7 @@ Globals:
     PermissionsBoundary:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     ReservedConcurrentExecutions: 10
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     Timeout: 30
     MemorySize: 256
     Architectures:

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "lint-staged": "15.5.0",
         "prettier": "3.5.3",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": "^22.0.0"
       }
     },
     "infrastructure/audit-test-tools": {
@@ -54,6 +57,9 @@
         "ts-node": "10.9.2",
         "typescript": "5.8.2",
         "yaml-cfn": "0.3.2"
+      },
+      "engines": {
+        "node": "^22.0.0"
       }
     },
     "infrastructure/audit-test-tools/node_modules/@aws-lambda-powertools/commons": {
@@ -205,6 +211,9 @@
         "ts-node": "10.9.2",
         "typescript": "5.8.2",
         "yaml-cfn": "0.3.2"
+      },
+      "engines": {
+        "node": "^22.0.0"
       }
     },
     "infrastructure/dev-tools/node_modules/@aws-lambda-powertools/commons": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "scripts": {
     "lint": "prettier . --check || exit 1 ; eslint . --max-warnings=0",
     "lint:fix": "prettier . --write ; eslint . --fix",
-    "postinstall": "husky install",
-    "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
+    "postinstall": "husky",
     "validate:templates": "bash ./scripts/validate-templates.sh"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "lint-staged": {
     "*": "prettier --write",
     "*.{js,ts}": "eslint --fix"
+  },
+  "engines": {
+    "node": "^22.0.0"
   }
 }


### PR DESCRIPTION
- migrate to node 18
- remove recommended extension as we no longer use yarn
- add minimum node version