### PR TITLE
DPT-1723 - remove extra `'`

### DIFF
--- a/infrastructure/core/template.yaml
+++ b/infrastructure/core/template.yaml
@@ -268,7 +268,7 @@ Resources:
               Resource: '*'
               Condition:
                 ArnLike:
-                  aws:PrincipalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/*pipeline-TestRole*'
+                  aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/*pipeline-TestRole*'
             - !Ref AWS::NoValue
 
   SecretsKmsKeyAlias:


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/DPT-1723

```
aws:PrincipalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/*pipeline-TestRole*' (previous)
aws:PrincipalArn: !Sub 'arn:aws:iam::${AWS::AccountId}:role/*pipeline-TestRole*'  (proposed change)
```

in `PrincipalArn` theres an extra `'` which aws didnt like. manual fix applied in ssf build so one that passes, this is the permanant fix