### PR TITLE
DPT1653 - Unify Github Actions and Docker across all Repositories | txma-infra

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '03:00'
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    ignore:
+      - dependency-name: 'node'
+        versions: ['21.x']
+    commit-message:
+      prefix: BAU
+
+  - package-ecosystem: 'docker'
+    directory: '/tests'
+    schedule:
+      interval: daily
+      time: '03:00'
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    commit-message:
+      prefix: BAU
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: daily
+    target-branch: main
+    labels:
+      - dependabot
+      - dependencies
+    commit-message:
+      prefix: BAU

--- a/.github/workflows/ensure-sha-pinned-actions.yaml
+++ b/.github/workflows/ensure-sha-pinned-actions.yaml
@@ -1,0 +1,17 @@
+name: Ensure SHA pinned actions
+
+on: push
+
+jobs:
+  harden_security:
+    name: Harden Security
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fc87bb5b5a97953d987372e74478de634726b3e5 # v3.0.25
+        with:
+          allowlist: |
+            aws-actions/
+            docker/login-action

--- a/.github/workflows/package-audit-test-tools.yaml
+++ b/.github/workflows/package-audit-test-tools.yaml
@@ -85,7 +85,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-audit-test-tools.yaml
+++ b/.github/workflows/package-audit-test-tools.yaml
@@ -22,9 +22,9 @@ jobs:
         working-directory: infrastructure/audit-test-tools
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -74,7 +74,7 @@ jobs:
         with:
           name: audit-test-tools-sam-template
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-audit-test-tools.yaml
+++ b/.github/workflows/package-audit-test-tools.yaml
@@ -85,7 +85,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-audit-test-tools.yaml
+++ b/.github/workflows/package-audit-test-tools.yaml
@@ -39,7 +39,7 @@ jobs:
         if: always()
         run: npm run build
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: audit-test-tools-sam-template
           path: |
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: audit-test-tools-sam-template
       - name: Setup Python 3.8

--- a/.github/workflows/package-audit.yaml
+++ b/.github/workflows/package-audit.yaml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-audit.yaml
+++ b/.github/workflows/package-audit.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-audit.yaml
+++ b/.github/workflows/package-audit.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -64,9 +64,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -77,7 +77,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-core.yaml
+++ b/.github/workflows/package-core.yaml
@@ -77,7 +77,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -33,9 +33,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-data-analysis.yaml
+++ b/.github/workflows/package-data-analysis.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -118,7 +118,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -118,7 +118,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -40,7 +40,7 @@ jobs:
         if: always()
         run: npm run build
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dev-tools-sam-template
           path: |

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -22,7 +22,7 @@ jobs:
         working-directory: infrastructure/dev-tools
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node 22
         uses: actions/setup-node@v3
         with:
@@ -107,7 +107,7 @@ jobs:
         with:
           name: dev-tools-sam-template
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-dev-tools.yaml
+++ b/.github/workflows/package-dev-tools.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node 22
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dev-tools-sam-template
       - name: Setup Python 3.8

--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-event-processing.yaml
+++ b/.github/workflows/package-event-processing.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET]}}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -33,9 +33,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-query-results.yaml
+++ b/.github/workflows/package-query-results.yaml
@@ -46,7 +46,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-rp-events.yaml
+++ b/.github/workflows/package-rp-events.yaml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-rp-events.yaml
+++ b/.github/workflows/package-rp-events.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-rp-events.yaml
+++ b/.github/workflows/package-rp-events.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-shared-signals.yaml
+++ b/.github/workflows/package-shared-signals.yaml
@@ -32,9 +32,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/package-shared-signals.yaml
+++ b/.github/workflows/package-shared-signals.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@v3.8.1
+        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/package-shared-signals.yaml
+++ b/.github/workflows/package-shared-signals.yaml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ secrets[matrix.GH_ACTIONS_ROLE_ARN_SECRET] }}
       - name: Package SAM app
-        uses: govuk-one-login/devplatform-upload-action@86306cee24f5578f26626dbc67bfd08910101ff6 # vskip-canary
+        uses: govuk-one-login/devplatform-upload-action@4aea54e8885223b8d92b23b3dbf3bf5ee7f44003 # v3.10.0
         with:
           artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_BUCKET_NAME_SECRET] }}
           signing-profile-name: ${{ secrets[matrix.SIGNING_PROFILE_SECRET] }}

--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Python 3.8
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Setup Node 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm
@@ -37,7 +37,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Setup Python 3.8
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.8'
       - name: Setup SAM CLI

--- a/.github/workflows/pre-merge-checks.yaml
+++ b/.github/workflows/pre-merge-checks.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Validate SAM templates
         run: ./scripts/validate-templates.sh
       - name: Run Checkov on SAM templates
-        uses: bridgecrewio/checkov-action@master
+        uses: bridgecrewio/checkov-action@4f966d0f4ad18f9d1c8fa484530d67d1ada2931a # v12.3027.0
         with:
           directory: infrastructure/
           quiet: true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "prettier . --check || exit 1 ; eslint . --max-warnings=0",
     "lint:fix": "prettier . --write ; eslint . --fix",
     "validate:templates": "bash ./scripts/validate-templates.sh",
-    "prepare": "husky"
+    "prepare": "husky",
+    "updateGitHubActions": "./updateGitHubActions.sh"
   },
   "dependencies": {
     "@aws-sdk/client-sso-oidc": "3.758.0",

--- a/updateGitHubActions.sh
+++ b/updateGitHubActions.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# This will search the git workflows for references to github repositories and fetch the latest tag information
+# and edit the files with the correct sha version, commenting with the tag name.
+
+# To run this, you will need to create a personal access token in github and pass it as the env variable `GITHUB_TOKEN`
+
+if [ -z "$GITHUB_TOKEN" ]
+then
+  echo "\$GITHUB_TOKEN is not defined."
+  exit 1
+fi
+
+fileList=$(ls .github/workflows/*.yaml)
+
+doRepo () {
+	allTags=$(curl -s --request GET --url https://api.github.com/repos/$1/tags --header "Authorization: Bearer ${GITHUB_TOKEN}" --header "X-GitHub-Api-Version: 2022-11-28" | jq -r '.[0]')
+	tagName=$(jq -r '.name' <<< "$allTags")
+	tagSha=$(jq -r '.commit.sha' <<< "$allTags")
+	echo "${1}@${tagSha} # ${tagName}"
+}
+
+for fileName in $fileList; do
+  echo "Updating $fileName"
+  repos=`grep uses ${fileName} | awk '{print $2}'  | awk -F '@' '{print $1}'`
+
+  for repo in  $repos; do
+    repoString=$(doRepo $repo)
+    repoEscaped=$(sed 's/[/]/\\\//g' <<<"$repo")
+    repoStringEscaped=$(sed 's/[/]/\\\//g' <<<"$repoString")
+    # Differences in BSD and GNU sed mean it's easier to create backups and delete them later
+    sed -i.bak "s/${repoEscaped}.*/${repoStringEscaped}/g" "./$fileName"
+  done
+done
+
+rm .github/workflows/*.bak


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/DPT-1653

💡 Description
Security updates for test builds and dependancies

✨ Changes Made
Add dependabot config to watch for updates to npm packages, docker images, and GitHub actions that we depend on.
Add an action to ensure all external GitHub actions are pinned to a specific commit SHA to prevent supply chain attacks.
Add a script to help keep GitHub actions up to date
Pinned all dependant GitHub actions to specific commit SHAs

🧪 Testing Instructions/Notes
This only affects the CI pipelines. Check that the builds are still working as expected.

See parent ticket https://govukverify.atlassian.net/browse/DPT-1637 for more details
