### PR TITLE
SET-883 - DynamoDB |  Create Alarms for Read/Write throttling

### DIFF
--- a/infrastructure/rp-events/template.yaml
+++ b/infrastructure/rp-events/template.yaml
@@ -162,6 +162,98 @@ Resources:
       ManagedPolicyArns:
         - !Ref RelyingPartyPairwiseMappingTableCrossAccountAccessPolicy
 
+  ####################
+  # CloudWatch Alarms
+  ####################
+
+  RelyingPartyConfigTableReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors read throttle events on the RelyingPartyConfig DynamoDB table.
+        Triggers when any read throttle events occur within a 5 minute period.
+      AlarmName: !Sub ${AWS::StackName}-rp-config-table-read-throttle-events
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: TableName
+          Value: !Ref RelyingPartyConfigTable
+      EvaluationPeriods: 1
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  RelyingPartyConfigTableWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors write throttle events on the RelyingPartyConfig DynamoDB table.
+        Triggers when any write throttle events occur within a 5 minute period.
+      AlarmName: !Sub ${AWS::StackName}-rp-config-table-write-throttle-events
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: TableName
+          Value: !Ref RelyingPartyConfigTable
+      EvaluationPeriods: 1
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  RelyingPartyPairwiseMappingTableReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors read throttle events on the RelyingPartyPairwiseMapping DynamoDB table.
+        Triggers when any read throttle events occur within a 5 minute period.
+      AlarmName: !Sub ${AWS::StackName}-rp-pairwise-mapping-table-read-throttle-events
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: TableName
+          Value: !Ref RelyingPartyPairwiseMappingTable
+      EvaluationPeriods: 1
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  RelyingPartyPairwiseMappingTableWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors write throttle events on the RelyingPartyPairwiseMapping DynamoDB table.
+        Triggers when any write throttle events occur within a 5 minute period.
+      AlarmName: !Sub ${AWS::StackName}-rp-pairwise-mapping-table-write-throttle-events
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: TableName
+          Value: !Ref RelyingPartyPairwiseMappingTable
+      EvaluationPeriods: 1
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300
+      Threshold: 0
+      TreatMissingData: notBreaching
+
   ################
   # SQS Resources
   ################

--- a/infrastructure/rp-events/template.yaml
+++ b/infrastructure/rp-events/template.yaml
@@ -173,7 +173,7 @@ Resources:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
         Alarm that monitors read throttle events on the RelyingPartyConfig DynamoDB table.
-        Triggers when any read throttle events occur within a 5 minute period.
+        Triggers when any read throttle events occur within a 1 minute period.
       AlarmName: !Sub ${AWS::StackName}-rp-config-table-read-throttle-events
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -184,7 +184,7 @@ Resources:
       MetricName: ReadThrottleEvents
       Namespace: AWS/DynamoDB
       Statistic: Sum
-      Period: 300
+      Period: 60
       Threshold: 0
       TreatMissingData: notBreaching
 
@@ -195,7 +195,7 @@ Resources:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
         Alarm that monitors write throttle events on the RelyingPartyConfig DynamoDB table.
-        Triggers when any write throttle events occur within a 5 minute period.
+        Triggers when any write throttle events occur within a 1 minute period.
       AlarmName: !Sub ${AWS::StackName}-rp-config-table-write-throttle-events
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -206,7 +206,7 @@ Resources:
       MetricName: WriteThrottleEvents
       Namespace: AWS/DynamoDB
       Statistic: Sum
-      Period: 300
+      Period: 60
       Threshold: 0
       TreatMissingData: notBreaching
 
@@ -217,7 +217,7 @@ Resources:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
         Alarm that monitors read throttle events on the RelyingPartyPairwiseMapping DynamoDB table.
-        Triggers when any read throttle events occur within a 5 minute period.
+        Triggers when any read throttle events occur within a 1 minute period.
       AlarmName: !Sub ${AWS::StackName}-rp-pairwise-mapping-table-read-throttle-events
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -228,7 +228,7 @@ Resources:
       MetricName: ReadThrottleEvents
       Namespace: AWS/DynamoDB
       Statistic: Sum
-      Period: 300
+      Period: 60
       Threshold: 0
       TreatMissingData: notBreaching
 
@@ -239,7 +239,7 @@ Resources:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
         Alarm that monitors write throttle events on the RelyingPartyPairwiseMapping DynamoDB table.
-        Triggers when any write throttle events occur within a 5 minute period.
+        Triggers when any write throttle events occur within a 1 minute period.
       AlarmName: !Sub ${AWS::StackName}-rp-pairwise-mapping-table-write-throttle-events
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -250,7 +250,7 @@ Resources:
       MetricName: WriteThrottleEvents
       Namespace: AWS/DynamoDB
       Statistic: Sum
-      Period: 300
+      Period: 60
       Threshold: 0
       TreatMissingData: notBreaching
 

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -110,6 +110,54 @@ Resources:
         Enabled: true
 
   ####################
+  # CloudWatch Alarms
+  ####################
+
+  UserConfigTableReadThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors read throttle events on the UserConfig DynamoDB table.
+        Triggers when any read throttle events occur within a 5 minute period.
+      AlarmName: !Sub ${AWS::StackName}-user-config-table-read-throttle-events
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: TableName
+          Value: !Ref UserConfigTable
+      EvaluationPeriods: 1
+      MetricName: ReadThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  UserConfigTableWriteThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
+      AlarmDescription: >-
+        Alarm that monitors write throttle events on the UserConfig DynamoDB table.
+        Triggers when any write throttle events occur within a 5 minute period.
+      AlarmName: !Sub ${AWS::StackName}-user-config-table-write-throttle-events
+      ComparisonOperator: GreaterThanThreshold
+      DatapointsToAlarm: 1
+      Dimensions:
+        - Name: TableName
+          Value: !Ref UserConfigTable
+      EvaluationPeriods: 1
+      MetricName: WriteThrottleEvents
+      Namespace: AWS/DynamoDB
+      Statistic: Sum
+      Period: 300
+      Threshold: 0
+      TreatMissingData: notBreaching
+
+  ####################
   # Cognito Resources
   ####################
 

--- a/infrastructure/shared-signals/template.yaml
+++ b/infrastructure/shared-signals/template.yaml
@@ -120,7 +120,7 @@ Resources:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
         Alarm that monitors read throttle events on the UserConfig DynamoDB table.
-        Triggers when any read throttle events occur within a 5 minute period.
+        Triggers when any read throttle events occur within a 1 minute period.
       AlarmName: !Sub ${AWS::StackName}-user-config-table-read-throttle-events
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -131,7 +131,7 @@ Resources:
       MetricName: ReadThrottleEvents
       Namespace: AWS/DynamoDB
       Statistic: Sum
-      Period: 300
+      Period: 60
       Threshold: 0
       TreatMissingData: notBreaching
 
@@ -142,7 +142,7 @@ Resources:
         - !ImportValue txma-alarms-slack-alerts-BuildNotificationTopicArn
       AlarmDescription: >-
         Alarm that monitors write throttle events on the UserConfig DynamoDB table.
-        Triggers when any write throttle events occur within a 5 minute period.
+        Triggers when any write throttle events occur within a 1 minute period.
       AlarmName: !Sub ${AWS::StackName}-user-config-table-write-throttle-events
       ComparisonOperator: GreaterThanThreshold
       DatapointsToAlarm: 1
@@ -153,7 +153,7 @@ Resources:
       MetricName: WriteThrottleEvents
       Namespace: AWS/DynamoDB
       Statistic: Sum
-      Period: 300
+      Period: 60
       Threshold: 0
       TreatMissingData: notBreaching
 


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/SET-883

💡 Description
- Added ReadThrottleEvents and WriteThrottleEvents alarms for UserConfigTable in shared-signals
- Added ReadThrottleEvents and WriteThrottleEvents alarms for RelyingPartyConfigTable in rp-events
- Added ReadThrottleEvents and WriteThrottleEvents alarms for RelyingPartyPairwiseMappingTable in rp-events


✨ Changes Made
- Added ReadThrottleEvents and WriteThrottleEvents alarms for UserConfigTable in shared-signals
- Added ReadThrottleEvents and WriteThrottleEvents alarms for RelyingPartyConfigTable in rp-events
- Added ReadThrottleEvents and WriteThrottleEvents alarms for RelyingPartyPairwiseMappingTable in rp-events


🧪 Testing Instructions/Notes
Testing of alarms will be done after merging 
