### PR TITLE
DPT-3036 Enable feature branches to grant their own access to the Firehose KMS key

### DIFF
--- a/infrastructure/core/template.yaml
+++ b/infrastructure/core/template.yaml
@@ -135,7 +135,11 @@ Resources:
               - kms:Encrypt
               - kms:GenerateDataKey*
               - kms:DescribeKey
+              - kms:CreateGrant
             Resource: '*'
+            Condition:
+              Bool:
+                kms:GrantIsForAWSResource: true
 
   FirehoseKmsKeyAlias:
     Type: AWS::KMS::Alias


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/DPT-3036

💡 Description
For feature branches on the dev account to run integration tests, they need to be able to grant themselves access to the KMS key used to encrypt and decrypt the Audit events. 

This is so that test events can be created and sent through the audit process.


✨ Changes Made

FirehoseKmsKey now has kms:CreateGrant enabled.

🧪 Testing Instructions/Notes
N/A

This should enable the integration tests to run on a feature branch in audit-dev account and stop the error:

`Error: Lambda Error in function txma-audit-dev-tools-add-firehose-record: InvalidKMSResourceException - Put to delivery stream dpt-3036-message-batch failed for account 725018305812. The grant for the CMK arn:aws:kms:eu-west-2:725018305812:key/d0471fec-9c7a-4e6f-94cd-b965d42524a0 to this delivery stream might have been revoked or caller might not have sufficient permissions for the CMK`

