### PR TITLE
DPT-3036 Enable feature branches to grant their own access to the Firehose KMS key

### DIFF
--- a/infrastructure/core/template.yaml
+++ b/infrastructure/core/template.yaml
@@ -20,6 +20,7 @@ Parameters:
 Conditions:
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, none]]
   TestEnvironment: !Equals [!Ref Environment, build]
+  DevEnvironment: !Equals [!Ref Environment, dev]
   CslsS3Logs:
     !Or [
       !Equals [!Ref Environment, production],
@@ -135,11 +136,24 @@ Resources:
               - kms:Encrypt
               - kms:GenerateDataKey*
               - kms:DescribeKey
-              - kms:CreateGrant
             Resource: '*'
-            Condition:
-              Bool:
-                kms:GrantIsForAWSResource: true
+          - !If
+            - DevEnvironment
+            - Sid: Allow Codepipeline test role to access encrypted secrets
+              Effect: Allow
+              Principal:
+                AWS: '*'
+              Action:
+                - kms:Decrypt
+                - kms:Encrypt
+                - kms:GenerateDataKey*
+                - kms:DescribeKey
+                - kms:CreateGrant
+              Resource: '*'
+              Condition:
+                Bool:
+                  kms:GrantIsForAWSResource: true
+            - !Ref AWS::NoValue
 
   FirehoseKmsKeyAlias:
     Type: AWS::KMS::Alias


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/DPT-3036

💡 Description
This extends the previous change, it allows any resource to create the grant on the KMS key, but this is only for Dev environments. Therefore not compromising security in higher environments.


✨ Changes Made
In infra core FirehoseKmsKey allows any AWS resource in the dev environment to create a grant on it for encryption, decryption etc.

🧪 Testing Instructions/Notes

This should enable the integration tests to run on a feature branch in audit-dev account and stop the error:

Error: Lambda Error in function txma-audit-dev-tools-add-firehose-record: InvalidKMSResourceException - Put to delivery stream dpt-3036-message-batch failed for account 725018305812. The grant for the CMK arn:aws:kms:eu-west-2:725018305812:key/d0471fec-9c7a-4e6f-94cd-b965d42524a0 to this delivery stream might have been revoked or caller might not have sufficient permissions for the CMK
