### PR TITLE
DPT-3036 Add KMS access for AuditMessageDeliveryStream in dev-tools

### DIFF
--- a/infrastructure/core/template.yaml
+++ b/infrastructure/core/template.yaml
@@ -139,7 +139,7 @@ Resources:
             Resource: '*'
           - !If
             - DevEnvironment
-            - Sid: Allow Codepipeline test role to access encrypted secrets
+            - Sid: Allow Integration test runner role to access encrypted secrets
               Effect: Allow
               Principal:
                 AWS: '*'

--- a/infrastructure/dev-tools/template.yaml
+++ b/infrastructure/dev-tools/template.yaml
@@ -116,6 +116,10 @@ Resources:
                 - kms:Encrypt
                 - kms:GenerateDataKey*
                 - kms:DescribeKey
+              Resource:
+                - '{{resolve:ssm:FirehoseKmsKeyArn}}'
+            - Effect: Allow
+              Action:
                 - kms:CreateGrant
               Resource:
                 - '{{resolve:ssm:FirehoseKmsKeyArn}}'

--- a/infrastructure/dev-tools/template.yaml
+++ b/infrastructure/dev-tools/template.yaml
@@ -110,6 +110,18 @@ Resources:
               Action:
                 - firehose:PutRecord
               Resource: '*'
+            - Effect: Allow
+              Action:
+                - kms:Decrypt
+                - kms:Encrypt
+                - kms:GenerateDataKey*
+                - kms:DescribeKey
+                - kms:CreateGrant
+              Resource:
+                - '{{resolve:ssm:FirehoseKmsKeyArn}}'
+              Condition:
+                Bool:
+                  kms:GrantIsForAWSResource: true
 
   AddFirehoseRecordLogs:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Ticket Number: https://govukverify.atlassian.net/browse/DPT-3036

💡 Description
Experimental

Add KMS permissions to the Lambda that sends encrypted test data to the Audit data stream

✨ Changes Made
AddFirehoseRecordFunction is now allowed to access the KMS key used for encrypting and decrypting data for the Audit data stream

🧪 Testing Instructions/Notes
Run the audit integration tests on a feature branch. 
There shouldn't be any errors with getting a Grant on the KMS key
